### PR TITLE
Enumerator ranked order

### DIFF
--- a/src/RankedCollection/RankedCollection.cs
+++ b/src/RankedCollection/RankedCollection.cs
@@ -21,7 +21,7 @@ public class RankedCollection<T> : ICollection<RankedItem<T>> where T : notnull
 
     public bool Remove(RankedItem<T> item)
     {
-        var i = items.Find(ri => ri.Item.Equals(item.Item));
+        var i = items.Find(ri => ri.Value.Equals(item.Value));
         if(i is RankedItem<T> ri)
         {
             ri.RankChanged -= RankedItem_RankChanged;
@@ -44,7 +44,7 @@ public class RankedCollection<T> : ICollection<RankedItem<T>> where T : notnull
 
     public void Clear() => items.Clear();
 
-    public bool Contains(RankedItem<T> item) => items.Find(ri => ri.Item.Equals(item.Item)) is not null;
+    public bool Contains(RankedItem<T> item) => items.Find(ri => ri.Value.Equals(item.Value)) is not null;
 
     public void CopyTo(RankedItem<T>[] array, int arrayIndex) =>
         items.CopyTo(array, arrayIndex);

--- a/src/RankedCollection/RankedCollection.cs
+++ b/src/RankedCollection/RankedCollection.cs
@@ -49,13 +49,7 @@ public class RankedCollection<T> : ICollection<RankedItem<T>> where T : notnull
     public void CopyTo(RankedItem<T>[] array, int arrayIndex) =>
         items.CopyTo(array, arrayIndex);
 
-    public IEnumerator<RankedItem<T>> GetEnumerator()
-    {
-        throw new NotImplementedException();
-    }
+    public IEnumerator<RankedItem<T>> GetEnumerator() => items.OrderByDescending(i => i.Rank).GetEnumerator();
 
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        throw new NotImplementedException();
-    }
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/RankedCollection/RankedCollection.cs
+++ b/src/RankedCollection/RankedCollection.cs
@@ -2,7 +2,7 @@
 
 namespace EnhancedCollections;
 
-public class RankedCollection<T> : ICollection<T> where T : notnull
+public class RankedCollection<T> : ICollection<RankedItem<T>> where T : notnull
 {
     readonly List<RankedItem<T>> items = new();
 
@@ -10,18 +10,18 @@ public class RankedCollection<T> : ICollection<T> where T : notnull
 
     public bool IsReadOnly => false;
 
-    public IRankedItem<T> this[int i] => items[i];
+    public RankedItem<T> this[int i] => items[i];
 
-    public void Add(T item)
+    public void Add(RankedItem<T> item)
     {
-        var rankedItem = new RankedItem<T>(item, items.Count + 1);
-        rankedItem.RankChanged += RankedItem_RankChanged;
-        items.Add(rankedItem);
+        item.SetRank(items.Count + 1);
+        item.RankChanged += RankedItem_RankChanged;
+        items.Add(item);
     }
 
-    public bool Remove(T item)
+    public bool Remove(RankedItem<T> item)
     {
-        var i = items.Find(ri => ri.Item.Equals(item));
+        var i = items.Find(ri => ri.Item.Equals(item.Item));
         if(i is RankedItem<T> ri)
         {
             ri.RankChanged -= RankedItem_RankChanged;
@@ -32,7 +32,7 @@ public class RankedCollection<T> : ICollection<T> where T : notnull
         return false;
     }
 
-    private int RankedItem_RankChanged(IRankedItem<T> item, int desiredRank)
+    private int RankedItem_RankChanged(RankedItem item, int desiredRank)
     {
         var displaced = items.Find(ri => ri.Rank == desiredRank);
         if (displaced is null)
@@ -44,12 +44,12 @@ public class RankedCollection<T> : ICollection<T> where T : notnull
 
     public void Clear() => items.Clear();
 
-    public bool Contains(T item) => items.Find(ri => ri.Item.Equals(item)) is not null;
+    public bool Contains(RankedItem<T> item) => items.Find(ri => ri.Item.Equals(item.Item)) is not null;
 
-    public void CopyTo(T[] array, int arrayIndex) =>
-        items.Select(ri => ri.Item).ToList().CopyTo(array, arrayIndex);
+    public void CopyTo(RankedItem<T>[] array, int arrayIndex) =>
+        items.CopyTo(array, arrayIndex);
 
-    public IEnumerator<T> GetEnumerator()
+    public IEnumerator<RankedItem<T>> GetEnumerator()
     {
         throw new NotImplementedException();
     }

--- a/src/RankedCollection/RankedItem.cs
+++ b/src/RankedCollection/RankedItem.cs
@@ -33,13 +33,13 @@ public class RankedItem
 
 public class RankedItem<T> : RankedItem
 {
-    public T Item { get; }
+    public T Value { get; }
 
-    internal RankedItem(T item)
+    internal RankedItem(T value)
     {
-        Item = item;
+        Value = value;
     }
 
-    public static implicit operator T(RankedItem<T> rankedItem) => rankedItem.Item;
-    public static implicit operator RankedItem<T>(T item) => new RankedItem<T>(item);
+    public static implicit operator T(RankedItem<T> rankedItem) => rankedItem.Value;
+    public static implicit operator RankedItem<T>(T value) => new (value);
 }

--- a/src/RankedCollection/RankedItem.cs
+++ b/src/RankedCollection/RankedItem.cs
@@ -1,18 +1,7 @@
 ﻿namespace EnhancedCollections;
 
-public interface IRankedItem<T>
+public class RankedItem
 {
-    T Item { get; }
-    int Rank { get; set; }
-
-    void Promote();
-    void Demote();
-}
-
-internal class RankedItem<T> : IRankedItem<T> where T : notnull
-{
-    public T Item { get; }
-
     int _rank;
     public int Rank
     {
@@ -23,31 +12,34 @@ internal class RankedItem<T> : IRankedItem<T> where T : notnull
             {
                 //TODO: normalize entered rank if out of bounds
                 int? newRank = RankChanged?.Invoke(this, value);
-                if(newRank.HasValue)
+                if (newRank.HasValue)
                     _rank = newRank.Value;
             }
         }
     }
 
-    public event RankChangedEvent? RankChanged;
-    public delegate int RankChangedEvent(IRankedItem<T> item, int desiredRank);
+    public void Promote() => Rank--;
+    public void Demote() => Rank++;
 
-    public RankedItem(T item, int rank)
-    {
-        Item = item;
-        _rank = rank;
-    }
+    internal event RankChangedEvent? RankChanged;
+    internal delegate int RankChangedEvent(RankedItem item, int desiredRank);
 
     /// <summary>
     /// Use to cascade rank shifts through list without firing infinite events
     /// </summary>
     /// <param name="i"></param>
-    public void SetRank(int i) => _rank = i;
+    internal void SetRank(int i) => _rank = i;
+}
 
-    public void Promote() => Rank--;
+public class RankedItem<T> : RankedItem
+{
+    public T Item { get; }
 
-    public void Demote() => Rank++;
-
+    internal RankedItem(T item)
+    {
+        Item = item;
+    }
 
     public static implicit operator T(RankedItem<T> rankedItem) => rankedItem.Item;
+    public static implicit operator RankedItem<T>(T item) => new RankedItem<T>(item);
 }

--- a/src/RankedCollection/RankedItem.cs
+++ b/src/RankedCollection/RankedItem.cs
@@ -31,7 +31,7 @@ public class RankedItem
     internal void SetRank(int i) => _rank = i;
 }
 
-public class RankedItem<T> : RankedItem
+public class RankedItem<T> : RankedItem where T : notnull
 {
     public T Value { get; }
 

--- a/test/RankedCollection.UnitTests/CollectionImplementationTests.cs
+++ b/test/RankedCollection.UnitTests/CollectionImplementationTests.cs
@@ -30,6 +30,6 @@ public class CollectionImplementationTests
 
         var arr = new RankedItem<char>[sut.Count];
         sut.CopyTo(arr, 0);
-        arr[0].Item.Should().Be('c');
+        arr[0].Value.Should().Be('c');
     }
 }

--- a/test/RankedCollection.UnitTests/CollectionImplementationTests.cs
+++ b/test/RankedCollection.UnitTests/CollectionImplementationTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using EnhancedCollections;
 using FluentAssertions;
 using Xunit;
@@ -9,7 +10,7 @@ public class CollectionImplementationTests
 {
     [Fact]
     public void ICollectionImplemented()
-    {        
+    {
         ICollection<RankedItem<char>> sut = new RankedCollection<char>();
 
         sut.Add('a');
@@ -31,5 +32,21 @@ public class CollectionImplementationTests
         var arr = new RankedItem<char>[sut.Count];
         sut.CopyTo(arr, 0);
         arr[0].Value.Should().Be('c');
+    }
+
+    [Fact]
+    public void EnumeratesInRankDescendingOrder()
+    {
+        var sut = new RankedCollection<string>() {
+            "Turkey",
+            "Bacon",
+            "Ham"
+        };
+        sut[1].Promote();
+        sut.Select(ri => ri.Value).Should().BeEquivalentTo(new[]{
+            "Bacon",
+            "Turkey",
+            "Ham"
+            });
     }
 }

--- a/test/RankedCollection.UnitTests/CollectionImplementationTests.cs
+++ b/test/RankedCollection.UnitTests/CollectionImplementationTests.cs
@@ -9,8 +9,8 @@ public class CollectionImplementationTests
 {
     [Fact]
     public void ICollectionImplemented()
-    {
-        ICollection<char> sut = new RankedCollection<char>();
+    {        
+        ICollection<RankedItem<char>> sut = new RankedCollection<char>();
 
         sut.Add('a');
         sut.Add('b');
@@ -28,8 +28,8 @@ public class CollectionImplementationTests
         sut.Contains('c').Should().BeTrue();
         sut.Contains('a').Should().BeFalse();
 
-        var arr = new char[sut.Count];
+        var arr = new RankedItem<char>[sut.Count];
         sut.CopyTo(arr, 0);
-        arr[0].Should().Be('c');
+        arr[0].Item.Should().Be('c');
     }
 }

--- a/test/RankedCollection.UnitTests/PromoteDemoteTests.cs
+++ b/test/RankedCollection.UnitTests/PromoteDemoteTests.cs
@@ -18,15 +18,15 @@ public class PromoteDemoteTests
     {
         var sut = CreateTestSubject();
 
-        IRankedItem<string> ye = sut[0];
+        RankedItem<string> ye = sut[0];
         ye.Rank.Should().Be(1);
         ye.Item.Should().Be("Kanye");
 
-        IRankedItem<string> hov = sut[1];
+        RankedItem<string> hov = sut[1];
         hov.Rank.Should().Be(2);
         hov.Item.Should().Be("Jay-Z");
 
-        IRankedItem<string> biggie = sut[2];
+        RankedItem<string> biggie = sut[2];
         biggie.Rank.Should().Be(3);
         biggie.Item.Should().Be("Notorious B.I.G.");
     }
@@ -35,7 +35,7 @@ public class PromoteDemoteTests
     public void PromoteOnce()
     {
         var sut = CreateTestSubject();
-        IRankedItem<string> hov = sut[1];
+        RankedItem<string> hov = sut[1];
         hov.Rank.Should().Be(2);
         hov.Promote();
         hov.Rank.Should().Be(1);
@@ -45,7 +45,7 @@ public class PromoteDemoteTests
     public void PromoteTwiceInBounds()
     {
         var sut = CreateTestSubject();
-        IRankedItem<string> biggie = sut[2];
+        RankedItem<string> biggie = sut[2];
         biggie.Rank.Should().Be(3);
         biggie.Promote();
         biggie.Promote();
@@ -56,7 +56,7 @@ public class PromoteDemoteTests
     public void PromoteOnceOutOfBounds()
     {
         var sut = CreateTestSubject();
-        IRankedItem<string> ye = sut[0];
+        RankedItem<string> ye = sut[0];
         ye.Rank.Should().Be(1);
         ye.Promote();
         ye.Rank.Should().Be(1);
@@ -66,7 +66,7 @@ public class PromoteDemoteTests
     public void DemoteOnce()
     {
         var sut = CreateTestSubject();
-        IRankedItem<string> hov = sut[1];
+        RankedItem<string> hov = sut[1];
         hov.Rank.Should().Be(2);
         hov.Demote();
         hov.Rank.Should().Be(3);
@@ -76,7 +76,7 @@ public class PromoteDemoteTests
     public void DemoteTwiceInBounds()
     {
         var sut = CreateTestSubject();
-        IRankedItem<string> ye = sut[0];
+        RankedItem<string> ye = sut[0];
         ye.Rank.Should().Be(1);
         ye.Demote();
         ye.Demote();
@@ -87,7 +87,7 @@ public class PromoteDemoteTests
     public void DemoteOnceOutOfBounds()
     {
         var sut = CreateTestSubject();
-        IRankedItem<string> biggie = sut[2];
+        RankedItem<string> biggie = sut[2];
         biggie.Rank.Should().Be(3);
         biggie.Demote();
         biggie.Rank.Should().Be(3);

--- a/test/RankedCollection.UnitTests/PromoteDemoteTests.cs
+++ b/test/RankedCollection.UnitTests/PromoteDemoteTests.cs
@@ -20,15 +20,15 @@ public class PromoteDemoteTests
 
         RankedItem<string> ye = sut[0];
         ye.Rank.Should().Be(1);
-        ye.Item.Should().Be("Kanye");
+        ye.Value.Should().Be("Kanye");
 
         RankedItem<string> hov = sut[1];
         hov.Rank.Should().Be(2);
-        hov.Item.Should().Be("Jay-Z");
+        hov.Value.Should().Be("Jay-Z");
 
         RankedItem<string> biggie = sut[2];
         biggie.Rank.Should().Be(3);
-        biggie.Item.Should().Be("Notorious B.I.G.");
+        biggie.Value.Should().Be("Notorious B.I.G.");
     }
 
     [Fact]


### PR DESCRIPTION
Implemented `GetEnumerator` to always return in ranked order.

I wanted to be able to declare the generic as the type you'd like to use, but still be able to interact with the library's `RankedItem`.
That was accomplished by implementing `ICollection` with a different generic arg from the implementing class and letting anything implicitly cast to  `RankedItem<T>`.